### PR TITLE
msm8974-common: Use 64-bit binder API

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -45,6 +45,9 @@ TARGET_CPU_ABI := armeabi-v7a
 TARGET_CPU_ABI2 := armeabi
 TARGET_CPU_VARIANT := krait
 
+# Binder API version
+TARGET_USES_64_BIT_BINDER := true
+
 # Kernel
 BOARD_DTBTOOL_ARGS := --dt-tag "htc,project-id = <"
 BOARD_KERNEL_CMDLINE := console=none androidboot.hardware=qcom user_debug=31 ehci-hcd.park=3 zcache


### PR DESCRIPTION
AOSP and mainline are going towards removing old 32-bit binder API support.
64-bit binder is 100% compatible with 32-bit kernel and userspace,
so there is no reason for us to keep using the old solution anymore.
We've switched to new API in our kernel, same thing should be applied to our userspace.

Change-Id: I3c95bd7fbd023c5cb08e856b3a3889c03228e843